### PR TITLE
Fix redirect and display of qrcode image if machine name is not resolvable

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -55,7 +55,6 @@ module.exports = NodeHelper.create({
     this.expressApp.get("/modules/MMM-Config/review", (req, res) => {
       // redirect to config form
       res.redirect(
-        this.config.url +
           "/modules/" +
           this.name +
           "/config.html?port=" +

--- a/node_helper.js
+++ b/node_helper.js
@@ -152,8 +152,7 @@ module.exports = NodeHelper.create({
 
       if (this.config.showQR) {
         let url = this.config.url + "/modules/" + this.name + "/review";
-        let imageurl =
-          this.config.url + "/modules/" + this.name + "/qrfile.png";
+        let imageurl = "/modules/" + this.name + "/qrfile.png";
         QRCode.toFile(this.path + "/qrfile.png", url, (err) => {
           if (!err) {
             if (debug) console.log("QRCode build done");


### PR DESCRIPTION
If the machine name is not resolvable, then the qrcode image does not appear in the magic mirror and the redirect from http://machine_name:MM_Port/modules/MMM-Config/review to the config.html file is unsuccessful.

This pull request uses relative URLs for the redirect and qrcode imageurl.
